### PR TITLE
chore: lock yarn version

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.13.0.js


### PR DESCRIPTION
# TL;DR
Yarn v2 is probably incompatible with the current project. So, lock the yarn version at 1.